### PR TITLE
Fix navigation for reservations and reviews

### DIFF
--- a/RestaurantReservationApp/App.js
+++ b/RestaurantReservationApp/App.js
@@ -6,7 +6,7 @@ import HomeStackScreen from './screens/HomeStackScreen'; // ya da HomeStackScree
 
 // Diğer ekran bileşenlerini import edin:
 import FavoriteRestaurantsScreen from './screens/FavoriteRestaurantsScreen';
-import MyReservationsScreen from './screens/MyReservationsScreen';
+import ReservationsStackScreen from './screens/ReservationsStackScreen';
 import ProfileScreen from './screens/ProfileScreen';
 
 const Tab = createBottomTabNavigator();
@@ -27,7 +27,7 @@ export default function App() {
         />
         <Tab.Screen
           name="Reservations"
-          component={MyReservationsScreen}
+          component={ReservationsStackScreen}
           options={{ title: 'Rezervasyonlarım' }}
         />
         <Tab.Screen

--- a/RestaurantReservationApp/screens/HomeStackScreen.js
+++ b/RestaurantReservationApp/screens/HomeStackScreen.js
@@ -4,6 +4,7 @@ import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import RestaurantListScreen from './RestaurantListScreen';
 import RestaurantDetailsScreen from './RestaurantDetailsScreen';
 import ReservationScreen from './ReservationScreen';
+import ReviewScreen from './ReviewScreen';
 
 const HomeStack = createNativeStackNavigator();
 
@@ -20,10 +21,15 @@ export default function HomeStackScreen() {
         component={RestaurantDetailsScreen} 
         options={{ title: 'Restoran Detayları' }}
       />
-      <HomeStack.Screen 
-        name="Reservation" 
-        component={ReservationScreen} 
+      <HomeStack.Screen
+        name="Reservation"
+        component={ReservationScreen}
         options={{ title: 'Rezervasyon Oluştur' }}
+      />
+      <HomeStack.Screen
+        name="Review"
+        component={ReviewScreen}
+        options={{ title: 'Yorum Yap' }}
       />
     </HomeStack.Navigator>
   );

--- a/RestaurantReservationApp/screens/ReservationsStackScreen.js
+++ b/RestaurantReservationApp/screens/ReservationsStackScreen.js
@@ -1,0 +1,23 @@
+import React from 'react';
+import { createNativeStackNavigator } from '@react-navigation/native-stack';
+import MyReservationsScreen from './MyReservationsScreen';
+import ReservationDetailsScreen from './ReservationDetailsScreen';
+
+const ReservationsStack = createNativeStackNavigator();
+
+export default function ReservationsStackScreen() {
+  return (
+    <ReservationsStack.Navigator>
+      <ReservationsStack.Screen
+        name="MyReservations"
+        component={MyReservationsScreen}
+        options={{ title: 'Rezervasyonlarım' }}
+      />
+      <ReservationsStack.Screen
+        name="ReservationDetails"
+        component={ReservationDetailsScreen}
+        options={{ title: 'Rezervasyon Detayları' }}
+      />
+    </ReservationsStack.Navigator>
+  );
+}


### PR DESCRIPTION
## Summary
- add Review screen to the Home stack
- create ReservationsStack to include reservation details screen
- wire new stack into the bottom tab navigator

## Testing
- `npm test` *(fails: Missing script 'test')*

------
https://chatgpt.com/codex/tasks/task_e_6864392d75fc8324895ab60d1ee2bccf