### PR TITLE
Add admin stack navigation

### DIFF
--- a/RestaurantReservationApp/App.js
+++ b/RestaurantReservationApp/App.js
@@ -2,14 +2,41 @@
 import React from 'react';
 import { NavigationContainer } from '@react-navigation/native';
 import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
+import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import HomeStackScreen from './screens/HomeStackScreen'; // ya da HomeStackScreen'ı App.js içinde de tanımlayabilirsiniz
 
 // Diğer ekran bileşenlerini import edin:
 import FavoriteRestaurantsScreen from './screens/FavoriteRestaurantsScreen';
 import MyReservationsScreen from './screens/MyReservationsScreen';
 import ProfileScreen from './screens/ProfileScreen';
+import AdminPanelScreen from './screens/AdminPanelScreen';
+import AdminReservationsScreen from './screens/AdminReservationsScreen';
+import AdminRestaurantInfoScreen from './screens/AdminRestaurantInfoScreen';
 
 const Tab = createBottomTabNavigator();
+const AdminStack = createNativeStackNavigator();
+
+function AdminStackScreen() {
+  return (
+    <AdminStack.Navigator>
+      <AdminStack.Screen
+        name="AdminPanel"
+        component={AdminPanelScreen}
+        options={{ title: 'Y\u00f6netici Paneli' }}
+      />
+      <AdminStack.Screen
+        name="AdminReservations"
+        component={AdminReservationsScreen}
+        options={{ title: 'Rezervasyonlar' }}
+      />
+      <AdminStack.Screen
+        name="AdminRestaurantInfo"
+        component={AdminRestaurantInfoScreen}
+        options={{ title: 'Restoran Bilgileri' }}
+      />
+    </AdminStack.Navigator>
+  );
+}
 
 export default function App() {
   return (
@@ -34,6 +61,11 @@ export default function App() {
           name="Profile"
           component={ProfileScreen}
           options={{ title: 'Profil' }}
+        />
+        <Tab.Screen
+          name="AdminPanel"
+          component={AdminStackScreen}
+          options={{ title: 'Y\u00f6netici Paneli' }}
         />
       </Tab.Navigator>
     </NavigationContainer>


### PR DESCRIPTION
## Summary
- create `AdminStackScreen` inside `App.js`
- register `AdminPanel`, `AdminReservations`, and `AdminRestaurantInfo` screens
- expose the admin stack via the tab navigator

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68643cc463708324ab80a9def6f740cd