### PR TITLE
Update splash screen navigation comment

### DIFF
--- a/RestaurantReservationApp/screens/SplashScreen.js
+++ b/RestaurantReservationApp/screens/SplashScreen.js
@@ -21,7 +21,9 @@ export default function SplashScreen({ navigation }) {
         useNativeDriver: true,
       })
     ]).start(() => {
-      // Animasyon tamamlandığında kısa bir bekleme sonrası Login ekranına yönlendiriyoruz
+      // Animasyon tamamlandığında kısa bir bekleme sonrasında
+      // 'Login' adında bir rota tanımlıysa bu ekrana yönlendirilir
+      // (rota adı farklıysa burada ona göre güncellemeyi unutmayın)
       setTimeout(() => {
          navigation.replace('Login');
       }, 1000);


### PR DESCRIPTION
## Summary
- clarify that a `Login` route must exist for SplashScreen navigation

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68643e2548f883248763d1fa49f9f936