### PR TITLE
Fix missing ChangePassword navigation

### DIFF
--- a/RestaurantReservationApp/App.js
+++ b/RestaurantReservationApp/App.js
@@ -8,7 +8,7 @@ import HomeStackScreen from './screens/HomeStackScreen'; // ya da HomeStackScree
 // Diğer ekran bileşenlerini import edin:
 import FavoriteRestaurantsScreen from './screens/FavoriteRestaurantsScreen';
 import ReservationsStackScreen from './screens/ReservationsStackScreen';
-import ProfileScreen from './screens/ProfileScreen';
+import ProfileStackScreen from './screens/ProfileStackScreen';
 import AdminPanelScreen from './screens/AdminPanelScreen';
 import AdminReservationsScreen from './screens/AdminReservationsScreen';
 import AdminRestaurantInfoScreen from './screens/AdminRestaurantInfoScreen';
@@ -59,7 +59,7 @@ export default function App() {
         />
         <Tab.Screen
           name="Profile"
-          component={ProfileScreen}
+          component={ProfileStackScreen}
           options={{ title: 'Profil' }}
         />
         <Tab.Screen

--- a/RestaurantReservationApp/screens/ProfileStackScreen.js
+++ b/RestaurantReservationApp/screens/ProfileStackScreen.js
@@ -1,0 +1,23 @@
+import React from 'react';
+import { createNativeStackNavigator } from '@react-navigation/native-stack';
+import ProfileScreen from './ProfileScreen';
+import ChangePasswordScreen from './ChangePasswordScreen';
+
+const ProfileStack = createNativeStackNavigator();
+
+export default function ProfileStackScreen() {
+  return (
+    <ProfileStack.Navigator>
+      <ProfileStack.Screen
+        name="ProfileMain"
+        component={ProfileScreen}
+        options={{ title: 'Profil' }}
+      />
+      <ProfileStack.Screen
+        name="ChangePassword"
+        component={ChangePasswordScreen}
+        options={{ title: 'Şifre Güncelle' }}
+      />
+    </ProfileStack.Navigator>
+  );
+}


### PR DESCRIPTION
## Summary
- add a new Profile stack navigator so the change password screen is reachable
- use this new stack in `App.js`

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686441b84264832490a09fb305a91b10