### PR TITLE
Remove newArchEnabled setting

### DIFF
--- a/RestaurantReservationApp/app.json
+++ b/RestaurantReservationApp/app.json
@@ -6,7 +6,6 @@
     "orientation": "portrait",
     "icon": "./assets/icon.png",
     "userInterfaceStyle": "light",
-    "newArchEnabled": true,
     "splash": {
       "image": "./assets/splash-icon.png",
       "resizeMode": "contain",


### PR DESCRIPTION
## Summary
- remove `newArchEnabled` from `RestaurantReservationApp/app.json`

## Testing
- `npm start` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_68644ceaccdc8324af5281c6a89664ab