### PR TITLE
Add basic API and state management

### DIFF
--- a/RestaurantReservationApp/App.js
+++ b/RestaurantReservationApp/App.js
@@ -12,6 +12,8 @@ import ProfileStackScreen from './screens/ProfileStackScreen';
 import AdminPanelScreen from './screens/AdminPanelScreen';
 import AdminReservationsScreen from './screens/AdminReservationsScreen';
 import AdminRestaurantInfoScreen from './screens/AdminRestaurantInfoScreen';
+import AddRestaurantScreen from './screens/AddRestaurantScreen';
+import { RestaurantProvider } from './contexts/RestaurantContext';
 
 const Tab = createBottomTabNavigator();
 const AdminStack = createNativeStackNavigator();
@@ -34,18 +36,24 @@ function AdminStackScreen() {
         component={AdminRestaurantInfoScreen}
         options={{ title: 'Restoran Bilgileri' }}
       />
+      <AdminStack.Screen
+        name="AddRestaurant"
+        component={AddRestaurantScreen}
+        options={{ title: 'Yeni Restoran' }}
+      />
     </AdminStack.Navigator>
   );
 }
 
 export default function App() {
   return (
-    <NavigationContainer>
-      <Tab.Navigator>
-        <Tab.Screen
-          name="Home"
-          component={HomeStackScreen}
-          options={{ title: 'Ana Sayfa' }}
+    <RestaurantProvider>
+      <NavigationContainer>
+        <Tab.Navigator>
+          <Tab.Screen
+            name="Home"
+            component={HomeStackScreen}
+            options={{ title: 'Ana Sayfa' }}
         />
         <Tab.Screen
           name="Favorites"
@@ -68,6 +76,7 @@ export default function App() {
           options={{ title: 'Y\u00f6netici Paneli' }}
         />
       </Tab.Navigator>
-    </NavigationContainer>
+      </NavigationContainer>
+    </RestaurantProvider>
   );
 }

--- a/RestaurantReservationApp/contexts/RestaurantContext.js
+++ b/RestaurantReservationApp/contexts/RestaurantContext.js
@@ -1,0 +1,67 @@
+import React, { createContext, useContext, useEffect, useState } from 'react';
+
+const RestaurantContext = createContext();
+
+export function RestaurantProvider({ children }) {
+  const [restaurants, setRestaurants] = useState([]);
+  const [favorites, setFavorites] = useState([]);
+  const [reservations, setReservations] = useState([]);
+
+  useEffect(() => {
+    fetch('http://localhost:3001/restaurants')
+      .then(res => res.json())
+      .then(setRestaurants)
+      .catch(() => {});
+    fetch('http://localhost:3001/reservations')
+      .then(res => res.json())
+      .then(setReservations)
+      .catch(() => {});
+  }, []);
+
+  const toggleFavorite = (restaurant) => {
+    setFavorites((prev) => {
+      const exists = prev.find(r => r.id === restaurant.id);
+      if (exists) {
+        return prev.filter(r => r.id !== restaurant.id);
+      }
+      return [...prev, restaurant];
+    });
+  };
+
+  const addRestaurant = async (restaurant) => {
+    const res = await fetch('http://localhost:3001/restaurants', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(restaurant)
+    });
+    const data = await res.json();
+    setRestaurants(prev => [...prev, data]);
+  };
+
+  const updateRestaurant = async (id, data) => {
+    await fetch(`http://localhost:3001/restaurants/${id}`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(data)
+    });
+    setRestaurants(prev => prev.map(r => r.id === id ? { ...r, ...data } : r));
+  };
+
+  const addReservation = async (reservation) => {
+    const res = await fetch('http://localhost:3001/reservations', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(reservation)
+    });
+    const data = await res.json();
+    setReservations(prev => [...prev, data]);
+  };
+
+  return (
+    <RestaurantContext.Provider value={{ restaurants, favorites, reservations, toggleFavorite, addRestaurant, updateRestaurant, addReservation }}>
+      {children}
+    </RestaurantContext.Provider>
+  );
+}
+
+export const useRestaurant = () => useContext(RestaurantContext);

--- a/RestaurantReservationApp/screens/AddRestaurantScreen.js
+++ b/RestaurantReservationApp/screens/AddRestaurantScreen.js
@@ -1,0 +1,49 @@
+import React, { useState } from 'react';
+import { View, Text, TextInput, Button, StyleSheet, Alert } from 'react-native';
+import { useRestaurant } from '../contexts/RestaurantContext';
+
+export default function AddRestaurantScreen({ navigation }) {
+  const { addRestaurant } = useRestaurant();
+  const [name, setName] = useState('');
+  const [address, setAddress] = useState('');
+
+  const handleAdd = async () => {
+    if (!name || !address) return;
+    await addRestaurant({ name, address });
+    Alert.alert('Başarılı', 'Restoran eklendi.', [
+      { text: 'Tamam', onPress: () => navigation.goBack() }
+    ]);
+  };
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>Yeni Restoran Ekle</Text>
+      <TextInput
+        style={styles.input}
+        placeholder="Restoran Adı"
+        value={name}
+        onChangeText={setName}
+      />
+      <TextInput
+        style={styles.input}
+        placeholder="Adres"
+        value={address}
+        onChangeText={setAddress}
+      />
+      <Button title="Ekle" onPress={handleAdd} />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, padding: 20, justifyContent: 'center' },
+  title: { fontSize: 28, marginBottom: 20, textAlign: 'center' },
+  input: {
+    height: 50,
+    borderColor: '#ccc',
+    borderWidth: 1,
+    marginBottom: 15,
+    paddingHorizontal: 10,
+    borderRadius: 5,
+  },
+});

--- a/RestaurantReservationApp/screens/AdminPanelScreen.js
+++ b/RestaurantReservationApp/screens/AdminPanelScreen.js
@@ -8,6 +8,7 @@ export default function AdminPanelScreen({ navigation }) {
       <Text style={styles.title}>Restoran Yönetici Paneli</Text>
       <Button title="Rezervasyonları Görüntüle" onPress={() => navigation.navigate('AdminReservations')} />
       <Button title="Restoran Bilgilerini Güncelle" onPress={() => navigation.navigate('AdminRestaurantInfo')} />
+      <Button title="Yeni Restoran Ekle" onPress={() => navigation.navigate('AddRestaurant')} />
     </View>
   );
 }

--- a/RestaurantReservationApp/screens/AdminReservationsScreen.js
+++ b/RestaurantReservationApp/screens/AdminReservationsScreen.js
@@ -1,13 +1,10 @@
 // screens/AdminReservationsScreen.js
 import React from 'react';
 import { View, Text, FlatList, StyleSheet } from 'react-native';
-
-const reservations = [
-  { id: '1', restaurantName: 'Lezzetli Restoran', customer: 'Ahmet', date: '09/05/2025', time: '19:00', people: 2 },
-  { id: '2', restaurantName: 'Nefis Mutfağım', customer: 'Mehmet', date: '10/05/2025', time: '20:00', people: 4 },
-];
+import { useRestaurant } from '../contexts/RestaurantContext';
 
 export default function AdminReservationsScreen() {
+  const { reservations } = useRestaurant();
   const renderItem = ({ item }) => (
     <View style={styles.itemContainer}>
       <Text style={styles.itemTitle}>{item.restaurantName} - {item.customer}</Text>

--- a/RestaurantReservationApp/screens/AdminRestaurantInfoScreen.js
+++ b/RestaurantReservationApp/screens/AdminRestaurantInfoScreen.js
@@ -1,13 +1,22 @@
 // screens/AdminRestaurantInfoScreen.js
 import React, { useState } from 'react';
 import { View, TextInput, Button, Text, StyleSheet, Alert } from 'react-native';
+import { useRestaurant } from '../contexts/RestaurantContext';
 
 export default function AdminRestaurantInfoScreen() {
-  const [restaurantName, setRestaurantName] = useState('Lezzetli Restoran');
-  const [address, setAddress] = useState('İstanbul, Taksim');
-  const [description, setDescription] = useState('En iyi lezzetler burada!');
+  const { restaurants, updateRestaurant } = useRestaurant();
+  const restaurant = restaurants[0] || { name: '', address: '', description: '' };
+  const [restaurantName, setRestaurantName] = useState(restaurant.name);
+  const [address, setAddress] = useState(restaurant.address);
+  const [description, setDescription] = useState(restaurant.description || '');
 
-  const handleUpdate = () => {
+  const handleUpdate = async () => {
+    if (!restaurant.id) return;
+    await updateRestaurant(restaurant.id, {
+      name: restaurantName,
+      address,
+      description
+    });
     Alert.alert('Güncelleme Başarılı', 'Restoran bilgileri güncellendi.');
   };
 

--- a/RestaurantReservationApp/screens/FavoriteRestaurantsScreen.js
+++ b/RestaurantReservationApp/screens/FavoriteRestaurantsScreen.js
@@ -1,13 +1,10 @@
 // screens/FavoriteRestaurantsScreen.js
 import React from 'react';
 import { View, Text, FlatList, TouchableOpacity, StyleSheet } from 'react-native';
-
-const favorites = [
-  { id: '1', name: 'Lezzetli Restoran', address: 'İstanbul, Taksim' },
-  { id: '2', name: 'Nefis Mutfağım', address: 'Ankara, Çankaya' },
-];
+import { useRestaurant } from '../contexts/RestaurantContext';
 
 export default function FavoriteRestaurantsScreen({ navigation }) {
+  const { favorites } = useRestaurant();
   const renderItem = ({ item }) => (
     <TouchableOpacity
       style={styles.itemContainer}

--- a/RestaurantReservationApp/screens/MyReservationsScreen.js
+++ b/RestaurantReservationApp/screens/MyReservationsScreen.js
@@ -1,13 +1,10 @@
 // screens/MyReservationsScreen.js
 import React from 'react';
 import { View, Text, FlatList, TouchableOpacity, StyleSheet } from 'react-native';
-
-const reservations = [
-  { id: '1', restaurantName: 'Lezzetli Restoran', date: '09/05/2025', time: '19:00', people: 2 },
-  { id: '2', restaurantName: 'Nefis Mutfağım', date: '10/05/2025', time: '20:00', people: 4 },
-];
+import { useRestaurant } from '../contexts/RestaurantContext';
 
 export default function MyReservationsScreen({ navigation }) {
+  const { reservations } = useRestaurant();
   const renderItem = ({ item }) => (
     <TouchableOpacity
       style={styles.itemContainer}

--- a/RestaurantReservationApp/screens/ReservationScreen.js
+++ b/RestaurantReservationApp/screens/ReservationScreen.js
@@ -1,16 +1,22 @@
 import React, { useState } from 'react';
 import { View, Text, TextInput, Button, StyleSheet, Alert } from 'react-native';
+import { useRestaurant } from '../contexts/RestaurantContext';
 
 export default function ReservationScreen({ route, navigation }) {
   // Eğer restoran bilgisi gönderildiyse alıyoruz
   const { restaurant } = route.params;
+  const { addReservation } = useRestaurant();
   const [date, setDate] = useState('');
   const [time, setTime] = useState('');
   const [people, setPeople] = useState('');
 
-  const handleReservation = () => {
-    // Burada gerçek rezervasyon işlemleri API ile entegre edilebilir.
-    // Şimdilik basit bir uyarı mesajı ile rezervasyon bilgilerini gösterelim.
+  const handleReservation = async () => {
+    await addReservation({
+      restaurantName: restaurant.name,
+      date,
+      time,
+      people
+    });
     Alert.alert(
       'Rezervasyon Oluşturuldu',
       `Restoran: ${restaurant.name}\nTarih: ${date}\nSaat: ${time}\nKişi Sayısı: ${people}`,

--- a/RestaurantReservationApp/screens/RestaurantDetailsScreen.js
+++ b/RestaurantReservationApp/screens/RestaurantDetailsScreen.js
@@ -1,13 +1,14 @@
-import React, { useState } from 'react';
+import React from 'react';
 import { View, Text, StyleSheet, Button, ScrollView, Alert } from 'react-native';
+import { useRestaurant } from '../contexts/RestaurantContext';
 
 export default function RestaurantDetailsScreen({ route, navigation }) {
   const { restaurant } = route.params;
-  const [isFavorite, setIsFavorite] = useState(false);
+  const { favorites, toggleFavorite, addReservation } = useRestaurant();
+  const isFavorite = favorites.some(r => r.id === restaurant.id);
 
   const handleAddFavorite = () => {
-    // Favori durumu tersine çevriliyor
-    setIsFavorite(!isFavorite);
+    toggleFavorite(restaurant);
     Alert.alert(
       isFavorite ? 'Favoriden Çıkarıldı' : 'Favorilere Eklendi',
       isFavorite ? 'Restoran favorilerden çıkarıldı.' : 'Restoran favorilere eklendi.'

--- a/RestaurantReservationApp/screens/RestaurantListScreen.js
+++ b/RestaurantReservationApp/screens/RestaurantListScreen.js
@@ -1,13 +1,9 @@
 import React from 'react';
 import { View, Text, FlatList, TouchableOpacity, StyleSheet } from 'react-native';
-
-const restaurants = [
-  { id: '1', name: 'Lezzetli Restoran', address: 'İstanbul, Taksim' },
-  { id: '2', name: 'Nefis Mutfağım', address: 'Ankara, Çankaya' },
-  { id: '3', name: 'Enfes Yemekler', address: 'İzmir, Alsancak' },
-];
+import { useRestaurant } from '../contexts/RestaurantContext';
 
 export default function RestaurantListScreen({ navigation }) {
+  const { restaurants } = useRestaurant();
   const renderItem = ({ item }) => (
     <TouchableOpacity
       style={styles.itemContainer}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "restaurant-api",
+  "version": "1.0.0",
+  "main": "server.js",
+  "license": "MIT",
+  "dependencies": {
+    "cors": "^2.8.5",
+    "express": "^4.18.2"
+  },
+  "scripts": {
+    "start": "node server.js"
+  }
+}

--- a/server.js
+++ b/server.js
@@ -1,0 +1,44 @@
+const express = require('express');
+const app = express();
+const cors = require('cors');
+app.use(cors());
+app.use(express.json());
+
+let restaurants = [
+  { id: '1', name: 'Lezzetli Restoran', address: 'İstanbul, Taksim' },
+  { id: '2', name: 'Nefis Mutfağım', address: 'Ankara, Çankaya' },
+  { id: '3', name: 'Enfes Yemekler', address: 'İzmir, Alsancak' }
+];
+
+let reservations = [];
+
+app.get('/restaurants', (req, res) => {
+  res.json(restaurants);
+});
+
+app.post('/restaurants', (req, res) => {
+  const { name, address } = req.body;
+  const newRestaurant = { id: String(Date.now()), name, address };
+  restaurants.push(newRestaurant);
+  res.status(201).json(newRestaurant);
+});
+
+app.put('/restaurants/:id', (req, res) => {
+  const { id } = req.params;
+  const index = restaurants.findIndex(r => r.id === id);
+  if (index === -1) return res.status(404).end();
+  restaurants[index] = { ...restaurants[index], ...req.body };
+  res.json(restaurants[index]);
+});
+
+app.get('/reservations', (req, res) => {
+  res.json(reservations);
+});
+
+app.post('/reservations', (req, res) => {
+  const newReservation = { id: String(Date.now()), ...req.body };
+  reservations.push(newReservation);
+  res.status(201).json(newReservation);
+});
+
+app.listen(3001, () => console.log('API running on port 3001')); 


### PR DESCRIPTION
## Summary
- add an Express server with restaurant and reservation endpoints
- manage restaurants, favourites and reservations via context
- update all screens to use new context
- add screen for adding restaurants and hook up admin navigation

## Testing
- `npm test --silent` in `/RestaurantReservationApp`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_686451c7abc88324abe2c4a068f70102