### PR TITLE
Add basic authentication flow and fix reservation features

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,12 @@ After installing, you can start the Expo development server:
 npm start
 ```
 
+## Backend API
+
+This repository also includes a small Express based API used for restaurant and reservation data. From the repository root install its dependencies and start the server:
+
+```bash
+npm install
+npm start # runs server.js on port 3001
+```
+

--- a/RestaurantReservationApp/App.js
+++ b/RestaurantReservationApp/App.js
@@ -14,9 +14,14 @@ import AdminReservationsScreen from './screens/AdminReservationsScreen';
 import AdminRestaurantInfoScreen from './screens/AdminRestaurantInfoScreen';
 import AddRestaurantScreen from './screens/AddRestaurantScreen';
 import { RestaurantProvider } from './contexts/RestaurantContext';
+import { AuthProvider, useAuth } from './contexts/AuthContext';
+import SplashScreen from './screens/SplashScreen';
+import LoginScreen from './screens/LoginScreen';
+import RegisterScreen from './screens/RegisterScreen';
 
 const Tab = createBottomTabNavigator();
 const AdminStack = createNativeStackNavigator();
+const RootStack = createNativeStackNavigator();
 
 function AdminStackScreen() {
   return (
@@ -45,38 +50,64 @@ function AdminStackScreen() {
   );
 }
 
+function AppTabs() {
+  return (
+    <Tab.Navigator>
+      <Tab.Screen
+        name="Home"
+        component={HomeStackScreen}
+        options={{ title: 'Ana Sayfa' }}
+      />
+      <Tab.Screen
+        name="Favorites"
+        component={FavoriteRestaurantsScreen}
+        options={{ title: 'Favoriler' }}
+      />
+      <Tab.Screen
+        name="Reservations"
+        component={ReservationsStackScreen}
+        options={{ title: 'Rezervasyonlarım' }}
+      />
+      <Tab.Screen
+        name="Profile"
+        component={ProfileStackScreen}
+        options={{ title: 'Profil' }}
+      />
+      <Tab.Screen
+        name="AdminPanel"
+        component={AdminStackScreen}
+        options={{ title: 'Y\u00f6netici Paneli' }}
+      />
+    </Tab.Navigator>
+  );
+}
+
+function AppContent() {
+  const { user } = useAuth();
+
+  return (
+    <NavigationContainer>
+      <RootStack.Navigator screenOptions={{ headerShown: false }}>
+        {!user ? (
+          <>
+            <RootStack.Screen name="Splash" component={SplashScreen} />
+            <RootStack.Screen name="Login" component={LoginScreen} />
+            <RootStack.Screen name="Register" component={RegisterScreen} />
+          </>
+        ) : (
+          <RootStack.Screen name="AppTabs" component={AppTabs} />
+        )}
+      </RootStack.Navigator>
+    </NavigationContainer>
+  );
+}
+
 export default function App() {
   return (
-    <RestaurantProvider>
-      <NavigationContainer>
-        <Tab.Navigator>
-          <Tab.Screen
-            name="Home"
-            component={HomeStackScreen}
-            options={{ title: 'Ana Sayfa' }}
-        />
-        <Tab.Screen
-          name="Favorites"
-          component={FavoriteRestaurantsScreen}
-          options={{ title: 'Favoriler' }}
-        />
-        <Tab.Screen
-          name="Reservations"
-          component={ReservationsStackScreen}
-          options={{ title: 'Rezervasyonlarım' }}
-        />
-        <Tab.Screen
-          name="Profile"
-          component={ProfileStackScreen}
-          options={{ title: 'Profil' }}
-        />
-        <Tab.Screen
-          name="AdminPanel"
-          component={AdminStackScreen}
-          options={{ title: 'Y\u00f6netici Paneli' }}
-        />
-      </Tab.Navigator>
-      </NavigationContainer>
-    </RestaurantProvider>
+    <AuthProvider>
+      <RestaurantProvider>
+        <AppContent />
+      </RestaurantProvider>
+    </AuthProvider>
   );
 }

--- a/RestaurantReservationApp/contexts/AuthContext.js
+++ b/RestaurantReservationApp/contexts/AuthContext.js
@@ -1,0 +1,22 @@
+import React, { createContext, useContext, useState } from 'react';
+
+const AuthContext = createContext();
+
+export function AuthProvider({ children }) {
+  const [user, setUser] = useState(null);
+
+  const login = (email) => {
+    // For this demo simply set user object. Real app would verify credentials.
+    setUser({ email });
+  };
+
+  const logout = () => setUser(null);
+
+  return (
+    <AuthContext.Provider value={{ user, login, logout }}>
+      {children}
+    </AuthContext.Provider>
+  );
+}
+
+export const useAuth = () => useContext(AuthContext);

--- a/RestaurantReservationApp/contexts/RestaurantContext.js
+++ b/RestaurantReservationApp/contexts/RestaurantContext.js
@@ -1,4 +1,8 @@
 import React, { createContext, useContext, useEffect, useState } from 'react';
+import Constants from 'expo-constants';
+
+const API_HOST = Constants.manifest?.debuggerHost?.split(':').shift() || 'localhost';
+const API_URL = `http://${API_HOST}:3001`;
 
 const RestaurantContext = createContext();
 
@@ -8,11 +12,11 @@ export function RestaurantProvider({ children }) {
   const [reservations, setReservations] = useState([]);
 
   useEffect(() => {
-    fetch('http://localhost:3001/restaurants')
+    fetch(`${API_URL}/restaurants`)
       .then(res => res.json())
       .then(setRestaurants)
       .catch(() => {});
-    fetch('http://localhost:3001/reservations')
+    fetch(`${API_URL}/reservations`)
       .then(res => res.json())
       .then(setReservations)
       .catch(() => {});
@@ -29,17 +33,18 @@ export function RestaurantProvider({ children }) {
   };
 
   const addRestaurant = async (restaurant) => {
-    const res = await fetch('http://localhost:3001/restaurants', {
+    const res = await fetch(`${API_URL}/restaurants`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(restaurant)
     });
+    if (!res.ok) throw new Error('Failed to add restaurant');
     const data = await res.json();
     setRestaurants(prev => [...prev, data]);
   };
 
   const updateRestaurant = async (id, data) => {
-    await fetch(`http://localhost:3001/restaurants/${id}`, {
+    await fetch(`${API_URL}/restaurants/${id}`, {
       method: 'PUT',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(data)
@@ -48,11 +53,12 @@ export function RestaurantProvider({ children }) {
   };
 
   const addReservation = async (reservation) => {
-    const res = await fetch('http://localhost:3001/reservations', {
+    const res = await fetch(`${API_URL}/reservations`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(reservation)
     });
+    if (!res.ok) throw new Error('Failed to add reservation');
     const data = await res.json();
     setReservations(prev => [...prev, data]);
   };

--- a/RestaurantReservationApp/screens/AddRestaurantScreen.js
+++ b/RestaurantReservationApp/screens/AddRestaurantScreen.js
@@ -9,10 +9,14 @@ export default function AddRestaurantScreen({ navigation }) {
 
   const handleAdd = async () => {
     if (!name || !address) return;
-    await addRestaurant({ name, address });
-    Alert.alert('Başarılı', 'Restoran eklendi.', [
-      { text: 'Tamam', onPress: () => navigation.goBack() }
-    ]);
+    try {
+      await addRestaurant({ name, address });
+      Alert.alert('Başarılı', 'Restoran eklendi.', [
+        { text: 'Tamam', onPress: () => navigation.goBack() }
+      ]);
+    } catch (e) {
+      Alert.alert('Hata', 'Restoran eklenemedi.');
+    }
   };
 
   return (

--- a/RestaurantReservationApp/screens/LoginScreen.js
+++ b/RestaurantReservationApp/screens/LoginScreen.js
@@ -1,14 +1,16 @@
 // LoginScreen.js
 import React, { useState } from 'react';
 import { View, Text, TextInput, Button, StyleSheet, TouchableOpacity } from 'react-native';
+import { useAuth } from '../contexts/AuthContext';
 
 export default function LoginScreen({ navigation }) {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
+  const { login } = useAuth();
 
   const handleLogin = () => {
     // Gerçek doğrulama işlemleri eklenebilir.
-    navigation.replace('Home');
+    login(email);
   };
 
   return (

--- a/RestaurantReservationApp/screens/ProfileScreen.js
+++ b/RestaurantReservationApp/screens/ProfileScreen.js
@@ -1,18 +1,20 @@
 // screens/ProfileScreen.js
 import React from 'react';
 import { View, Text, Button, StyleSheet } from 'react-native';
+import { useAuth } from '../contexts/AuthContext';
 
 export default function ProfileScreen({ navigation }) {
-  const user = { name: 'Ahmet Yılmaz', email: 'ahmet@example.com' };
+  const { user, logout } = useAuth();
 
   return (
     <View style={styles.container}>
       <Text style={styles.title}>Profil</Text>
       <Text style={styles.label}>İsim:</Text>
-      <Text style={styles.value}>{user.name}</Text>
+      <Text style={styles.value}>{user.name || user.email}</Text>
       <Text style={styles.label}>Email:</Text>
       <Text style={styles.value}>{user.email}</Text>
       <Button title="Şifre Güncelle" onPress={() => navigation.navigate('ChangePassword')} />
+      <Button title="Çıkış Yap" onPress={logout} />
     </View>
   );
 }

--- a/RestaurantReservationApp/screens/RegisterScreen.js
+++ b/RestaurantReservationApp/screens/RegisterScreen.js
@@ -1,13 +1,15 @@
 import React, { useState } from 'react';
 import { View, Text, TextInput, Button, StyleSheet } from 'react-native';
+import { useAuth } from '../contexts/AuthContext';
 
 export default function RegisterScreen({ navigation }) {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
+  const { login } = useAuth();
 
   const handleRegister = () => {
-    // Gerçek kayıt işlemleri burada yapılabilir; şimdilik kayıt sonrası giriş ekranına yönlendiriyoruz.
-    navigation.replace('Login');
+    // Gerçek kayıt işlemleri burada yapılabilir; şimdilik kullanıcıyı giriş yapmış varsayıyoruz.
+    login(email);
   };
 
   return (

--- a/RestaurantReservationApp/screens/ReservationScreen.js
+++ b/RestaurantReservationApp/screens/ReservationScreen.js
@@ -9,13 +9,15 @@ export default function ReservationScreen({ route, navigation }) {
   const [date, setDate] = useState('');
   const [time, setTime] = useState('');
   const [people, setPeople] = useState('');
+  const [customer, setCustomer] = useState('');
 
   const handleReservation = async () => {
     await addReservation({
       restaurantName: restaurant.name,
       date,
       time,
-      people
+      people,
+      customer
     });
     Alert.alert(
       'Rezervasyon Oluşturuldu',
@@ -30,6 +32,12 @@ export default function ReservationScreen({ route, navigation }) {
       {restaurant && (
         <Text style={styles.restaurantName}>Restoran: {restaurant.name}</Text>
       )}
+      <TextInput
+        style={styles.input}
+        placeholder="Adınız"
+        value={customer}
+        onChangeText={setCustomer}
+      />
       <TextInput
         style={styles.input}
         placeholder="Tarih (GG/AA/YYYY)"


### PR DESCRIPTION
## Summary
- implement `AuthContext` for simple login state management
- show login/register screens before accessing the app tabs
- add logout button to the profile screen
- allow entering customer name when making reservations
- handle API host dynamically and improve error handling
- update documentation for running the backend API

## Testing
- `cd RestaurantReservationApp && npm test`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6864542a707483248a3f81f51cd74429